### PR TITLE
Remove posts' content from search results

### DIFF
--- a/search/stores/es/types/post/actions.py
+++ b/search/stores/es/types/post/actions.py
@@ -21,6 +21,7 @@ def get_rescore_statements_v1(query):
 
 
 def get_highlight_fields_v1(query):
+    fragment_size = 70
     return [
         HighlightField(
             'title',
@@ -29,7 +30,13 @@ def get_highlight_fields_v1(query):
                 'number_of_fragments': 0,
             },
         ),
-        HighlightField('content', {'fragment_size': 70, 'no_match_size': 70}),
+        HighlightField(
+            'content',
+            {
+                'fragment_size': fragment_size,
+                'no_match_size': fragment_size,
+            }
+        ),
     ]
 
 def get_excluded_source_fields_v1(query):

--- a/search/stores/es/types/post/actions.py
+++ b/search/stores/es/types/post/actions.py
@@ -31,3 +31,9 @@ def get_highlight_fields_v1(query):
         ),
         HighlightField('content', {'fragment_size': 70, 'no_match_size': 70}),
     ]
+
+def get_excluded_source_fields_v1(query):
+    fields = [
+        'content',
+    ]
+    return fields

--- a/search/stores/es/types/post/actions.py
+++ b/search/stores/es/types/post/actions.py
@@ -29,5 +29,5 @@ def get_highlight_fields_v1(query):
                 'number_of_fragments': 0,
             },
         ),
-        HighlightField('content', {'fragment_size': 70}),
+        HighlightField('content', {'fragment_size': 70, 'no_match_size': 70}),
     ]

--- a/search/tests/test_search_v2.py
+++ b/search/tests/test_search_v2.py
@@ -423,7 +423,7 @@ class Test(ESTestCase):
         )
 
     def test_search_category_locations(self):
-        # verify a normal search returns a person
+        # verify a normal search returns a post
         response = self.client.call_action('search_v2', query='San Francisco')
         self.assertTrue(sum(result.HasField('post') for result in response.result.results) > 0)
 

--- a/search/tests/test_search_v2.py
+++ b/search/tests/test_search_v2.py
@@ -643,9 +643,4 @@ class Test(ESTestCase):
             query='Arbiter',
             category=search_pb2.POSTS,
         )
-        results_have_content = False
-        for result in response.result.results:
-            post = result.post
-            if len(post.content) > 0:
-                results_have_content = True
-        self.assertFalse(results_have_content)
+        self.assertFalse(any([result.post.content for result in response.result.results]))

--- a/search/tests/test_search_v2.py
+++ b/search/tests/test_search_v2.py
@@ -425,14 +425,14 @@ class Test(ESTestCase):
     def test_search_category_locations(self):
         # verify a normal search returns a post
         response = self.client.call_action('search_v2', query='San Francisco')
-        self.assertTrue(sum(result.HasField('post') for result in response.result.results) > 0)
+        self.assertTrue(any([result.post.id for result in response.result.results]))
 
         response = self.client.call_action(
             'search_v2',
             query='San Francisco',
             category=search_pb2.LOCATIONS,
         )
-        self.assertTrue(sum(result.HasField('post') for result in response.result.results) == 0)
+        self.assertFalse(any([result.post.id for result in response.result.results]))
 
     def test_search_category_posts(self):
         # verify a normal search returns a person

--- a/search/tests/test_search_v2.py
+++ b/search/tests/test_search_v2.py
@@ -636,3 +636,16 @@ class Test(ESTestCase):
         tracking_details = hit.tracking_details
         self.assertEqual(tracking_details.document_id, profile.id)
         self.assertEqual(tracking_details.document_type, types.ProfileV1._doc_type.name)
+
+    def test_search_post_does_not_have_content(self):
+        response = self.client.call_action(
+            'search_v2',
+            query='Arbiter',
+            category=search_pb2.POSTS,
+        )
+        results_have_content = False
+        for result in response.result.results:
+            post = result.post
+            if len(post.content) > 0:
+                results_have_content = True
+        self.assertFalse(results_have_content)

--- a/search/tests/test_search_v2.py
+++ b/search/tests/test_search_v2.py
@@ -425,24 +425,14 @@ class Test(ESTestCase):
     def test_search_category_locations(self):
         # verify a normal search returns a person
         response = self.client.call_action('search_v2', query='San Francisco')
-        self.verify_top_results(
-            'post',
-            {'content': lambda x: 'San Francisco' in x},
-            response.result.results,
-        )
+        self.assertTrue(sum(result.HasField('post') for result in response.result.results) > 0)
 
         response = self.client.call_action(
             'search_v2',
             query='San Francisco',
             category=search_pb2.LOCATIONS,
         )
-        self.verify_top_results(
-            'post',
-            {'content': lambda x: 'San Francisco' in x},
-            response.result.results,
-            top_results=10,
-            should_be_present=False,
-        )
+        self.assertTrue(sum(result.HasField('post') for result in response.result.results) == 0)
 
     def test_search_category_posts(self):
         # verify a normal search returns a person
@@ -522,12 +512,8 @@ class Test(ESTestCase):
 
     def test_search_raw_content_match_higher_than_title_match(self):
         response = self.client.call_action('search_v2', query='video conferencing')
-        self.verify_top_results(
-            'post',
-            {'content': lambda x: 'video conferencing' in x},
-            response.result.results,
-            top_results=1,
-        )
+        hit = response.result.results[0]
+        self.assertIn('<mark>video</mark> <mark>conferencing</mark>', hit.highlight['content'])
 
     def test_search_team_display_name_highlighting_partial(self):
         response = self.client.call_action('search_v2', query='Dev', category=search_pb2.TEAMS)


### PR DESCRIPTION
This change uses Elasticsearch's source filtering to exclude the `content` field from being returned with search results, namely the `content` field of posts. However, this change will exclude any field named `content` across all document types as there doesn't seem to be a way to limit the exclusion to a specific document type.

In place of `content`, the first 70 characters of the post will be returned as a highlight (without `<mark>` tags) if there is no other content highlighted.
