### PR TITLE
Support "Add to Slack"

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -101,4 +101,4 @@ git+https://c9b60542c1a793a1bcc0b1e95ce3ab3d2da148c4:x-oauth-basic@github.com/ge
 git+https://c9b60542c1a793a1bcc0b1e95ce3ab3d2da148c4:x-oauth-basic@github.com/getcircle/protobuf-to-dict.git@1.1.0
 
 git+https://c9b60542c1a793a1bcc0b1e95ce3ab3d2da148c4:x-oauth-basic@github.com/getcircle/python-soa.git@1.0.2
-git+https://c9b60542c1a793a1bcc0b1e95ce3ab3d2da148c4:x-oauth-basic@github.com/getcircle/protobuf-registry.git@4.1.0
+git+https://c9b60542c1a793a1bcc0b1e95ce3ab3d2da148c4:x-oauth-basic@github.com/getcircle/protobuf-registry.git@add-to-slack

--- a/hooks/slack/views.py
+++ b/hooks/slack/views.py
@@ -7,6 +7,7 @@ from rest_framework import (
 )
 from rest_framework.renderers import JSONRenderer
 import service.control
+from django.conf import settings
 
 from services.token import make_admin_token
 
@@ -28,6 +29,8 @@ class SlackViewSet(viewsets.ViewSet):
 
     def perform_authentication(self, request, *args, **kwargs):
         logger.info('received slash command: %s', self.request.data)
+        if self.request.data['token'] != settings.SLACK_SLASH_COMMANDS_TOKEN:
+            raise exceptions.NotAuthenticated()
         team_id = self.request.data['team_id']
         try:
             request.slash_integration = service.control.get_object(

--- a/hooks/slack/views.py
+++ b/hooks/slack/views.py
@@ -29,9 +29,10 @@ class SlackViewSet(viewsets.ViewSet):
 
     def perform_authentication(self, request, *args, **kwargs):
         logger.info('received slash command: %s', self.request.data)
-        if self.request.data['token'] != settings.SLACK_SLASH_COMMANDS_TOKEN:
-            raise exceptions.NotAuthenticated()
+        token = self.request.data['token']
         team_id = self.request.data['team_id']
+        if token != settings.SLACK_SLASH_COMMANDS_TOKEN:
+            raise exceptions.NotAuthenticated()
         try:
             request.slash_integration = service.control.get_object(
                 service='organization',

--- a/hooks/slack/views.py
+++ b/hooks/slack/views.py
@@ -28,7 +28,7 @@ class SlackViewSet(viewsets.ViewSet):
 
     def perform_authentication(self, request, *args, **kwargs):
         logger.info('received slash command: %s', self.request.data)
-        token = self.request.data['token']
+        team_id = self.request.data['team_id']
         try:
             request.slash_integration = service.control.get_object(
                 service='organization',
@@ -36,7 +36,7 @@ class SlackViewSet(viewsets.ViewSet):
                 client_kwargs={'token': make_admin_token()},
                 return_object='integration',
                 integration_type=integration_pb2.SLACK_SLASH_COMMAND,
-                provider_uid=token,
+                provider_uid=team_id,
             )
         except service.control.CallActionError:
             # TODO if we want to get fancy we should emit a message back that

--- a/hooks/tests/slack/test_luno_draft.py
+++ b/hooks/tests/slack/test_luno_draft.py
@@ -4,6 +4,7 @@ from mock import patch
 from rest_framework import status
 from rest_framework.test import APIClient
 from slacker import Response
+from django.conf import settings
 
 from services.test import (
     fuzzy,
@@ -38,7 +39,7 @@ class Test(MockedTestCase):
 
     def _request_payload(self, **overrides):
         payload = {
-            'token': fuzzy.FuzzyText().fuzz(),
+            'token': settings.SLACK_SLASH_COMMANDS_TOKEN,
             'user_id': fuzzy.FuzzyText().fuzz(),
             'team_id': fuzzy.FuzzyText().fuzz(),
             'command': '/luno',

--- a/hooks/tests/slack/test_luno_draft.py
+++ b/hooks/tests/slack/test_luno_draft.py
@@ -40,6 +40,7 @@ class Test(MockedTestCase):
         payload = {
             'token': fuzzy.FuzzyText().fuzz(),
             'user_id': fuzzy.FuzzyText().fuzz(),
+            'team_id': fuzzy.FuzzyText().fuzz(),
             'command': '/luno',
             'text': '',
         }

--- a/hooks/tests/slack/test_luno_search.py
+++ b/hooks/tests/slack/test_luno_search.py
@@ -37,6 +37,7 @@ class Test(MockedTestCase):
         payload = {
             'token': fuzzy.FuzzyText().fuzz(),
             'user_id': fuzzy.FuzzyText().fuzz(),
+            'team_id': fuzzy.FuzzyText().fuzz(),
             'command': '/luno',
             'response_url': fuzzy.FuzzyText(prefix='https://').fuzz(),
             'text': '',

--- a/hooks/tests/slack/test_luno_search.py
+++ b/hooks/tests/slack/test_luno_search.py
@@ -2,6 +2,7 @@ import json
 from mock import patch
 from rest_framework import status
 from rest_framework.test import APIClient
+from django.conf import settings
 
 from services.test import (
     fuzzy,
@@ -35,7 +36,7 @@ class Test(MockedTestCase):
 
     def _request_payload(self, **overrides):
         payload = {
-            'token': fuzzy.FuzzyText().fuzz(),
+            'token': settings.SLACK_SLASH_COMMANDS_TOKEN,
             'user_id': fuzzy.FuzzyText().fuzz(),
             'team_id': fuzzy.FuzzyText().fuzz(),
             'command': '/luno',

--- a/hooks/tests/slack/test_slack_hooks.py
+++ b/hooks/tests/slack/test_slack_hooks.py
@@ -3,6 +3,7 @@ from protobufs.services.organization.containers import integration_pb2
 from rest_framework import status
 from rest_framework.test import APIClient
 from slacker import Response
+from django.conf import settings
 
 from services.test import (
     fuzzy,
@@ -23,7 +24,7 @@ class Test(MockedTestCase):
             organization_id=self.organization.id,
             profile_id=self.profile.id,
         )
-        self.slack_token = fuzzy.FuzzyText().fuzz()
+        self.slack_token = settings.SLACK_SLASH_COMMANDS_TOKEN
         self.api = APIClient()
 
     def _setup_test(self, patched):
@@ -91,7 +92,7 @@ class Test(MockedTestCase):
     def test_slack_hooks_luno_help(self, patched):
         self._setup_test(patched)
         response = self.api.post('/hooks/slack/', {
-            'token': fuzzy.FuzzyText().fuzz(),
+            'token': self.slack_token,
             'user_id': fuzzy.FuzzyText().fuzz(),
             'team_id': fuzzy.FuzzyText().fuzz(),
             'command': '/luno',

--- a/hooks/tests/slack/test_slack_hooks.py
+++ b/hooks/tests/slack/test_slack_hooks.py
@@ -40,18 +40,22 @@ class Test(MockedTestCase):
 
     def test_slack_hooks_slash_integration_doesnt_exist(self):
         slack_token = fuzzy.FuzzyText().fuzz()
+        team_id = fuzzy.FuzzyText().fuzz()
+        user_id = fuzzy.FuzzyText().fuzz()
         error = self.mock.get_mockable_call_action_error('organization', 'get_integration')
         self.mock.instance.register_mock_error(
             service='organization',
             action='get_integration',
             error=error,
-            provider_uid=slack_token,
+            provider_uid=team_id,
             integration_type=integration_pb2.SLACK_SLASH_COMMAND,
         )
-        response = self.api.post('/hooks/slack/', {'token': slack_token})
+        response = self.api.post('/hooks/slack/', {'token': slack_token, 'team_id': team_id, 'user_id': user_id})
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_slack_hooks_slack_api_integration_doesnt_exist(self):
+        slack_token = fuzzy.FuzzyText().fuzz()
+        team_id = fuzzy.FuzzyText().fuzz()
         error = self.mock.get_mockable_call_action_error('organization', 'get_integration')
         self.mock.instance.register_mock_error(
             service='organization',
@@ -59,7 +63,7 @@ class Test(MockedTestCase):
             error=error,
             integration_type=integration_pb2.SLACK_WEB_API,
         )
-        response = self.api.post('/hooks/slack/', {'token': fuzzy.FuzzyText().fuzz()})
+        response = self.api.post('/hooks/slack/', {'token': slack_token, 'team_id': team_id})
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     @patch('hooks.slack.actions.Slacker')
@@ -79,6 +83,7 @@ class Test(MockedTestCase):
         response = self.api.post('/hooks/slack/', {
             'token': fuzzy.FuzzyText().fuzz(),
             'user_id': fuzzy.FuzzyText().fuzz(),
+            'team_id': fuzzy.FuzzyText().fuzz(),
         })
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -88,6 +93,7 @@ class Test(MockedTestCase):
         response = self.api.post('/hooks/slack/', {
             'token': fuzzy.FuzzyText().fuzz(),
             'user_id': fuzzy.FuzzyText().fuzz(),
+            'team_id': fuzzy.FuzzyText().fuzz(),
             'command': '/luno',
             'text': '',
         })

--- a/organizations/actions.py
+++ b/organizations/actions.py
@@ -447,7 +447,7 @@ class EnableIntegration(PreRunParseTokenMixin, actions.Action):
             'details': self._get_details_object(),
         }
         if self.request.integration.slack_slash_command:
-            parameters['provider_uid'] = self.request.integration.slack_slash_command.token
+            parameters['provider_uid'] = self.request.integration.provider_uid
 
         try:
             integration = models.Integration.objects.from_protobuf(

--- a/organizations/tests/test_organization_integrations.py
+++ b/organizations/tests/test_organization_integrations.py
@@ -27,6 +27,7 @@ class OrganizationIntegrationTests(TestCase):
 
     def test_organization_enable_integration_slack_slash_command(self):
         slack_token = fuzzy.FuzzyText().fuzz()
+        team_id = fuzzy.FuzzyText().fuzz()
         response = self.client.call_action(
             'enable_integration',
             integration={
@@ -34,6 +35,7 @@ class OrganizationIntegrationTests(TestCase):
                 'slack_slash_command': {
                     'token': slack_token,
                 },
+                'provider_uid': team_id,
             },
         )
         self.assertEqual(
@@ -44,7 +46,7 @@ class OrganizationIntegrationTests(TestCase):
         self.assertEqual(details.token, slack_token)
 
         integration = models.Integration.objects.get(pk=response.result.integration.id)
-        self.assertEqual(integration.provider_uid, slack_token)
+        self.assertEqual(integration.provider_uid, team_id)
         self.assertEqual(integration.type, integration_pb2.SLACK_SLASH_COMMAND)
         self.assertEqual(integration.details, response.result.integration.slack_slash_command)
 

--- a/services/settings/__init__.py
+++ b/services/settings/__init__.py
@@ -311,3 +311,10 @@ EMAIL_HOOK_NOTIFICATION_FROM_ADDRESS = 'notifications@lunohq.com'
 SILENCED_SYSTEM_CHECKS = [
     'auth.W004',
 ]
+
+SLACK_AUTHORIZATION_URL = 'https://slack.com/oauth/authorize'
+SLACK_TOKEN_URL = 'https://slack.com/api/oauth.access'
+SLACK_CLIENT_ID = '20491676758.20491945958'
+SLACK_CLIENT_SECRET = '9c4ea16161c57b5065edb2ddaad78c22'
+SLACK_SLASH_COMMANDS_TOKEN = 'KvQ9yhUrHAxptRtSIrvjM3uX'
+SLACK_SCOPE = 'commands channels:history groups:history users:read'

--- a/users/actions.py
+++ b/users/actions.py
@@ -651,23 +651,23 @@ class GetAuthenticationInstructions(actions.Action):
             self.response.backend = authenticate_user_pb2.RequestV1.INTERNAL
 
 
-class GetSlackAuthenticationInstructions(actions.Action):
+class GetIntegrationAuthenticationInstructions(actions.Action):
 
-    required_fields = ('organization_domain', 'redirect_uri',)
+    required_fields = ('organization_domain', 'redirect_uri', 'provider',)
 
     type_validators = {
         'redirect_uri': [valid_redirect_uri],
     }
 
-    def _get_authorization_instructions(self, organization):
+    def _get_authorization_instructions(self, organization, provider):
         return get_authorization_instructions(
-            provider=user_containers.IdentityV1.SLACK,
+            provider=provider,
             organization=organization,
             redirect_uri=self.request.redirect_uri,
         )
 
-    def _populate_slack_instructions(self, organization):
-        self.response.authorization_url, _ = self._get_authorization_instructions(organization)
+    def _populate_instructions(self, organization, provider):
+        self.response.authorization_url, _ = self._get_authorization_instructions(organization, provider)
 
     def _get_organization(self, domain):
         try:
@@ -687,7 +687,7 @@ class GetSlackAuthenticationInstructions(actions.Action):
 
     def run(self, *args, **kwargs):
         organization = self._get_organization(self.request.organization_domain)
-        self._populate_slack_instructions(organization)
+        self._populate_instructions(organization, self.request.provider)
 
 
 class GetActiveDevices(actions.Action):

--- a/users/providers/__init__.py
+++ b/users/providers/__init__.py
@@ -8,3 +8,4 @@ from .base import (  # NOQA
 
 from .google import Provider as Google  # NOQA
 from .okta import Provider as Okta  # NOQA
+from .slack import Provider as Slack  # NOQA

--- a/users/providers/slack.py
+++ b/users/providers/slack.py
@@ -25,10 +25,11 @@ class Provider(base.BaseProvider):
     exception_to_error_map = {}
 
     @classmethod
-    def get_authorization_url(cls, organization, redirect_uri, **kwargs):
+    def get_authorization_url(cls, organization, user_id, redirect_uri, **kwargs):
         payload = {
             'domain': organization.domain,
             'redirect_uri': redirect_uri,
+            'user_id': user_id,
         }
         parameters = {
             'client_id': settings.SLACK_CLIENT_ID,
@@ -61,6 +62,7 @@ class Provider(base.BaseProvider):
 
     def complete_authorization(self, request, response, state):
         redirect_uri = state.get('redirect_uri')
+        user_id = state.get('user_id')
         domain = state['domain']
         organization = organization_models.Organization.objects.get(
             domain=domain
@@ -74,6 +76,7 @@ class Provider(base.BaseProvider):
 
         identity, _ = self.get_identity(credentials['team_id'], organization.id)
         identity.access_token = credentials['access_token']
+        identity.user_id = user_id
         return identity
 
     def finalize_authorization(self, user, identity, request, response):

--- a/users/providers/slack.py
+++ b/users/providers/slack.py
@@ -1,0 +1,100 @@
+import json
+import logging
+import urllib
+
+from django.conf import settings
+from protobufs.services.user import containers_pb2 as user_containers
+from protobufs.services.organization.containers import integration_pb2
+
+import requests
+import service.control
+
+from services.token import make_admin_token
+
+from . import base
+from .. import models
+from ..authentication import utils
+from organizations import models as organization_models
+
+logger = logging.getLogger(__name__)
+
+
+class Provider(base.BaseProvider):
+
+    type = user_containers.IdentityV1.SLACK
+    provider_profile = None
+
+    exception_to_error_map = {
+        base.MissingRequiredProfileFieldError: 'PROVIDER_PROFILE_FIELD_MISSING',
+    }
+
+    @classmethod
+    def get_authorization_url(cls, organization, redirect_uri, **kwargs):
+        payload = {
+            'domain': organization.domain,
+            'redirect_uri': redirect_uri,
+        }
+        parameters = {
+            'client_id': settings.SLACK_CLIENT_ID,
+            'scope': settings.SLACK_SCOPE,
+            'state': base.get_state_token(cls.type, payload=payload),
+        }
+        return '%s?%s' % (
+            settings.SLACK_AUTHORIZATION_URL,
+            urllib.urlencode(parameters),
+        )
+
+    def _get_credentials_from_code(self, code):
+        parameters = {
+            'client_id': settings.SLACK_CLIENT_ID,
+            'client_secret': settings.SLACK_CLIENT_SECRET,
+            'code': code,
+        }
+        response = requests.get(
+            settings.SLACK_TOKEN_URL,
+            params=parameters
+        )
+        if not response.ok:
+            raise base.ExchangeError(response)
+
+        try:
+            payload = response.json()
+        except ValueError:
+            raise base.ExchangeError(response)
+        return payload
+
+    def complete_authorization(self, request, response, state):
+        redirect_uri = state.get('redirect_uri')
+        domain = state['domain']
+        organization = organization_models.Organization.objects.get(
+            domain=domain
+        )
+
+        authorization_code = request.oauth2_details.code
+        credentials = self._get_credentials_from_code(authorization_code)
+
+        if redirect_uri and utils.valid_redirect_uri(redirect_uri):
+            response.redirect_uri = redirect_uri
+
+        identity, _ = self.get_identity(credentials['team_id'], organization.id)
+        identity.access_token = credentials['access_token']
+        return identity
+
+    def finalize_authorization(self, user, identity, request, response):
+        organization = organization_models.Organization.objects.get(
+            pk=identity.organization_id,
+        )
+        token = make_admin_token(organization_id=str(organization.id))
+        client = service.control.Client('organization', token=token)
+        response = client.call_action('enable_integration', integration={
+            'integration_type': integration_pb2.SLACK_SLASH_COMMAND,
+            'slack_slash_command': {
+                'token': settings.SLACK_SLASH_COMMANDS_TOKEN,
+            },
+        })
+        response = client.call_action('enable_integration', integration={
+            'integration_type': integration_pb2.SLACK_WEB_API,
+            'slack_web_api': {
+                'token': identity.access_token,
+            },
+        })

--- a/users/providers/slack.py
+++ b/users/providers/slack.py
@@ -22,11 +22,7 @@ logger = logging.getLogger(__name__)
 class Provider(base.BaseProvider):
 
     type = user_containers.IdentityV1.SLACK
-    provider_profile = None
-
-    exception_to_error_map = {
-        base.MissingRequiredProfileFieldError: 'PROVIDER_PROFILE_FIELD_MISSING',
-    }
+    exception_to_error_map = {}
 
     @classmethod
     def get_authorization_url(cls, organization, redirect_uri, **kwargs):

--- a/users/providers/slack.py
+++ b/users/providers/slack.py
@@ -91,6 +91,7 @@ class Provider(base.BaseProvider):
             'slack_slash_command': {
                 'token': settings.SLACK_SLASH_COMMANDS_TOKEN,
             },
+            'provider_uid': identity.provider_uid,
         })
         response = client.call_action('enable_integration', integration={
             'integration_type': integration_pb2.SLACK_WEB_API,

--- a/users/server.py
+++ b/users/server.py
@@ -25,6 +25,7 @@ class Server(service.control.Server):
         'request_access': actions.RequestAccess,
         'delete_identity': actions.DeleteIdentity,
         'get_authentication_instructions': actions.GetAuthenticationInstructions,
+        'get_slack_authentication_instructions': actions.GetSlackAuthenticationInstructions,
         'get_active_devices': actions.GetActiveDevices,
         'bulk_update_users': actions.BulkUpdateUsers,
     }

--- a/users/server.py
+++ b/users/server.py
@@ -25,7 +25,7 @@ class Server(service.control.Server):
         'request_access': actions.RequestAccess,
         'delete_identity': actions.DeleteIdentity,
         'get_authentication_instructions': actions.GetAuthenticationInstructions,
-        'get_slack_authentication_instructions': actions.GetSlackAuthenticationInstructions,
+        'get_integration_authentication_instructions': actions.GetIntegrationAuthenticationInstructions,
         'get_active_devices': actions.GetActiveDevices,
         'bulk_update_users': actions.BulkUpdateUsers,
     }


### PR DESCRIPTION
This change adapts our current OAuth authentication flow to handle requests that are not for login and adds Slack as an identity provider to handle such requests for adding it as an integration. This change also adds a new  `get_integration_authentication_instructions` action which returns the authorization URL (with encoded state) for integrations that can be added.

**Other changes:**
- update slash command handler to check for our token
- stored `provider_uid` for slash command integration is now the Slack team ID, not the slash command token

**TODO:**
- [ ] register Luno as app on Slack and update constants for client ID, client secret, and slash command token
