### PR TITLE
Drafting from Slack: allow any character to be in the link text

### DIFF
--- a/hooks/slack/handlers/draft/actions.py
+++ b/hooks/slack/handlers/draft/actions.py
@@ -125,7 +125,7 @@ def replace_slack_links_with_post_links(text):
     # Catch both kinds of Slack links
     # with link text: <http://lunohq.com|Luno>
     # without link text: <http://lunohq.com>
-    new_text = re.sub(r'<([^@\s]+\://\S+)\|(\S+)>', r'<a href=\1>\2</a>', text)
+    new_text = re.sub(r'<([^@\s]+\://\S+)\|(.+)>', r'<a href=\1>\2</a>', text)
     new_text = re.sub(r'<([^@\s]+\://\S+)>', r'<a href=\1>\1</a>', new_text)
     return new_text
 

--- a/hooks/tests/slack/test_luno_draft.py
+++ b/hooks/tests/slack/test_luno_draft.py
@@ -158,8 +158,8 @@ class Test(MockedTestCase):
 
     def test_replace_slack_links_with_post_links(self):
         txt = 'check this out '
-        link = 'ftp://site.web/file.txt'
-        link_text = 'File'
+        link = 'ftp://site.web/screen_shot_2016-03-11_at_3.25.51_pm.png'
+        link_text = 'Screen Shot 2016-03-11 at 3.25.51 PM.png'
         slack_link = '<{link}>'.format(link=link)
         slack_link_with_link_text = '<{link}|{link_text}>'.format(link=link, link_text=link_text)
         post_link = '<a href={link}>{link}</a>'.format(link=link)


### PR DESCRIPTION
This change allows any character to be in the link text, which fixes a bug which caused links with whitespace in the link text to be parsed like so:

`<https: lunohq.slack.com="" files="" michael="" f0pn7qvex="" pasted_image_at_2016_03_01_08_44_am.png|pasted="" image="" at="" 2016-03-01,="" 8:44="" am="">`
